### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ it, simply add the following line to your Podfile:
     pod "AWFileHash"
 
 ### Manual
-Download the .zip, unpack it and draw the files "AWFileHash.{m,h}" into XCode. Make sure to add them to your target bundle also.
+Download the .zip, unpack it and draw the files "AWFileHash.{m,h}" into Xcode. Make sure to add them to your target bundle also.
 
 ## TODO
 


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
